### PR TITLE
feat: webcam bg removal, animated GIFs, Giphy clip integration

### DIFF
--- a/src/components/video-editor/CreativeWorkspace.tsx
+++ b/src/components/video-editor/CreativeWorkspace.tsx
@@ -103,6 +103,7 @@ interface CreativeWorkspaceProps {
 	onAddStickerAnnotation?: (emoji: string) => void;
 	onAddSoundEffect?: (soundId: SoundEffectId) => void;
 	onAddTransition?: (type: TransitionType) => void;
+	onRestoreClipToTimeline?: (clip: ScratchPadClip) => void;
 	hasVideo: boolean;
 }
 
@@ -198,6 +199,7 @@ export function CreativeWorkspace({
 	onAddStickerAnnotation,
 	onAddSoundEffect,
 	onAddTransition,
+	onRestoreClipToTimeline,
 	hasVideo,
 }: CreativeWorkspaceProps) {
 	const [noteInput, setNoteInput] = useState("");
@@ -306,11 +308,13 @@ export function CreativeWorkspace({
 
 	const handleRestoreScratchPadClip = useCallback((id: string) => {
 		const clip = scratchPadClips.find((c) => c.id === id);
-		if (clip) {
-			toast.success(`"${clip.label}" restored to timeline`);
-			onScratchPadClipsChange(scratchPadClips.filter((c) => c.id !== id));
+		if (!clip) return;
+
+		if (onRestoreClipToTimeline) {
+			onRestoreClipToTimeline(clip);
 		}
-	}, [scratchPadClips, onScratchPadClipsChange]);
+		onScratchPadClipsChange(scratchPadClips.filter((c) => c.id !== id));
+	}, [scratchPadClips, onScratchPadClipsChange, onRestoreClipToTimeline]);
 
 	// ── Core workspace callbacks ────────────────────────────────────────────
 

--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -69,8 +69,7 @@ import type { CaptionSettings } from "./captionStyle";
 import { DEFAULT_CAPTION_SETTINGS } from "./captionStyle";
 import { TRANSLATION_LANGUAGES } from "@/lib/ai/translationService";
 import { DUBBING_LANGUAGES } from "@/lib/ai/voiceDubbing";
-// AI Background Removal — shelved, will re-enable in AI features phase
-// import { WebcamBackgroundPanel } from "./WebcamBackgroundPanel";
+import { WebcamBackgroundPanel } from "./WebcamBackgroundPanel";
 import { WebcamPanel, type WebcamPanelProps } from "./WebcamPanel";
 
 const GRADIENTS = [
@@ -377,13 +376,12 @@ export function SettingsPanel({
 	onWebcamBorderWidthChange,
 	webcamShadow = 0,
 	onWebcamShadowChange,
-	// AI Background Removal — shelved, will re-enable in AI features phase
-	webcamBgMode: _webcamBgMode = "none",
-	onWebcamBgModeChange: _onWebcamBgModeChange,
-	webcamBgBlur: _webcamBgBlur = 10,
-	onWebcamBgBlurChange: _onWebcamBgBlurChange,
-	webcamBgColor: _webcamBgColor = "#00FF00",
-	onWebcamBgColorChange: _onWebcamBgColorChange,
+	webcamBgMode = "none",
+	onWebcamBgModeChange,
+	webcamBgBlur = 10,
+	onWebcamBgBlurChange,
+	webcamBgColor = "#00FF00",
+	onWebcamBgColorChange,
 	ambilightEnabled = true,
 	onAmbilightEnabledChange,
 	isExporting: _isExporting = false,
@@ -1044,7 +1042,6 @@ export function SettingsPanel({
 											webcamShadow={webcamShadow}
 											onWebcamShadowChange={onWebcamShadowChange}
 										/>
-										{/* AI Background Removal — shelved, will re-enable in AI features phase
 										{onWebcamBgModeChange && (
 											<WebcamBackgroundPanel
 												webcamBgMode={webcamBgMode}
@@ -1055,7 +1052,6 @@ export function SettingsPanel({
 												onWebcamBgColorChange={onWebcamBgColorChange ?? (() => undefined)}
 											/>
 										)}
-										*/}
 									</Accordion>
 								)}
 

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -1926,6 +1926,47 @@ export default function VideoEditor() {
 		setSelectedTrimId(null);
 	}, [currentTime, duration]);
 
+	const handleRestoreClipToTimeline = useCallback((clip: ScratchPadClip) => {
+		const gifUrl = clip.thumbnailUrl;
+		if (!gifUrl) {
+			toast.error("Clip has no image to add");
+			return;
+		}
+
+		// Fetch the GIF and convert to data URL for the annotation system
+		fetch(gifUrl)
+			.then((res) => res.blob())
+			.then((blob) => {
+				const reader = new FileReader();
+				reader.onloadend = () => {
+					const dataUrl = reader.result as string;
+					const startMs = Math.round(currentTime * 1000);
+					const endMs = Math.min(startMs + (clip.durationMs || 5000), Math.round(duration * 1000));
+					const id = `annotation-${nextAnnotationIdRef.current++}`;
+					const zIndex = nextAnnotationZIndexRef.current++;
+					const newRegion: AnnotationRegion = {
+						id,
+						startMs,
+						endMs,
+						type: "image",
+						content: dataUrl,
+						imageContent: dataUrl,
+						position: { x: 35, y: 35 },
+						size: { width: 30, height: 30 },
+						style: { ...DEFAULT_ANNOTATION_STYLE },
+						zIndex,
+					};
+					setAnnotationRegions((prev) => [...prev, newRegion]);
+					setSelectedAnnotationId(id);
+					toast.success(`"${clip.label}" added as overlay at ${(startMs / 1000).toFixed(1)}s`);
+				};
+				reader.readAsDataURL(blob);
+			})
+			.catch(() => {
+				toast.error("Failed to fetch clip image");
+			});
+	}, [currentTime, duration]);
+
 	const handleAddSoundEffect = useCallback((soundId: SoundEffectId) => {
 		const startMs = Math.round(currentTime * 1000);
 		const durationMs = Math.round(SFX_DURATIONS[soundId] * 1000);
@@ -2911,6 +2952,7 @@ export default function VideoEditor() {
 					onAddStickerAnnotation={handleStickerAnnotationAdded}
 					onAddSoundEffect={handleAddSoundEffect}
 					onAddTransition={handleAddTransition}
+					onRestoreClipToTimeline={handleRestoreClipToTimeline}
 					hasVideo={!!videoPath}
 				/>
 				<div className="flex-1 flex flex-col relative overflow-hidden">

--- a/src/lib/exporter/annotationRenderer.ts
+++ b/src/lib/exporter/annotationRenderer.ts
@@ -1,4 +1,5 @@
 import type { AnnotationRegion, ArrowDirection } from "@/components/video-editor/types";
+import { isGifDataUrl, decodeGif, getGifFrameAtTime } from "./gifFrameExtractor";
 
 // SVG path data for each arrow direction
 const ARROW_PATHS: Record<ArrowDirection, string[]> = {
@@ -215,6 +216,39 @@ function renderText(
 	ctx.restore();
 }
 
+/**
+ * Helper: draw an image source (Image or ImageBitmap) with aspect-ratio
+ * preservation ("contain" mode) inside the given bounding box.
+ */
+function drawContained(
+	ctx: CanvasRenderingContext2D,
+	source: CanvasImageSource,
+	srcW: number,
+	srcH: number,
+	x: number,
+	y: number,
+	width: number,
+	height: number,
+) {
+	const imgAspect = srcW / srcH;
+	const boxAspect = width / height;
+
+	let drawWidth = width;
+	let drawHeight = height;
+	let drawX = x;
+	let drawY = y;
+
+	if (imgAspect > boxAspect) {
+		drawHeight = width / imgAspect;
+		drawY = y + (height - drawHeight) / 2;
+	} else {
+		drawWidth = height * imgAspect;
+		drawX = x + (width - drawWidth) / 2;
+	}
+
+	ctx.drawImage(source, drawX, drawY, drawWidth, drawHeight);
+}
+
 async function renderImage(
 	ctx: CanvasRenderingContext2D,
 	annotation: AnnotationRegion,
@@ -222,32 +256,30 @@ async function renderImage(
 	y: number,
 	width: number,
 	height: number,
+	currentTimeMs: number,
 ): Promise<void> {
 	if (!annotation.content || !annotation.content.startsWith("data:image")) {
 		return;
 	}
 
+	// Animated GIF: decode frames and pick the right one for this timestamp
+	if (isGifDataUrl(annotation.content)) {
+		try {
+			const gif = await decodeGif(annotation.content);
+			const elapsedMs = currentTimeMs - annotation.startMs;
+			const frame = getGifFrameAtTime(gif, elapsedMs);
+			drawContained(ctx, frame, frame.width, frame.height, x, y, width, height);
+			return;
+		} catch {
+			// Fall through to static image rendering
+		}
+	}
+
+	// Static image
 	return new Promise((resolve) => {
 		const img = new Image();
 		img.onload = () => {
-			// Preserve aspect ratio - contain the image within the bounds
-			const imgAspect = img.width / img.height;
-			const boxAspect = width / height;
-
-			let drawWidth = width;
-			let drawHeight = height;
-			let drawX = x;
-			let drawY = y;
-
-			if (imgAspect > boxAspect) {
-				drawHeight = width / imgAspect;
-				drawY = y + (height - drawHeight) / 2;
-			} else {
-				drawWidth = height * imgAspect;
-				drawX = x + (width - drawWidth) / 2;
-			}
-
-			ctx.drawImage(img, drawX, drawY, drawWidth, drawHeight);
+			drawContained(ctx, img, img.width, img.height, x, y, width, height);
 			resolve();
 		};
 		img.onerror = () => {
@@ -286,7 +318,7 @@ export async function renderAnnotations(
 				break;
 
 			case "image":
-				await renderImage(ctx, annotation, x, y, width, height);
+				await renderImage(ctx, annotation, x, y, width, height, currentTimeMs);
 				break;
 
 			case "figure":

--- a/src/lib/exporter/gifFrameExtractor.ts
+++ b/src/lib/exporter/gifFrameExtractor.ts
@@ -1,0 +1,135 @@
+/**
+ * GIF frame extractor for rendering animated GIF annotations during export.
+ *
+ * Uses the Chromium ImageDecoder API to decode individual GIF frames,
+ * selecting the correct frame based on the current playback timestamp.
+ */
+
+/** Cached decoded GIF keyed by the first 64 chars of the data URL. */
+const gifCache = new Map<string, Promise<DecodedGif>>();
+
+interface DecodedGif {
+	frames: ImageBitmap[];
+	/** Cumulative end-time (ms) for each frame. */
+	frameTimes: number[];
+	totalDurationMs: number;
+}
+
+function cacheKey(dataUrl: string): string {
+	return dataUrl.slice(0, 128);
+}
+
+/**
+ * Returns true if a data-URL looks like an animated GIF.
+ */
+export function isGifDataUrl(dataUrl: string): boolean {
+	return dataUrl.startsWith("data:image/gif");
+}
+
+/**
+ * Decode all frames of a GIF data-URL into ImageBitmaps.
+ * Results are cached so repeated calls for the same GIF are free.
+ */
+export function decodeGif(dataUrl: string): Promise<DecodedGif> {
+	const key = cacheKey(dataUrl);
+	const cached = gifCache.get(key);
+	if (cached) return cached;
+
+	const promise = decodeGifInternal(dataUrl);
+	gifCache.set(key, promise);
+	return promise;
+}
+
+async function decodeGifInternal(dataUrl: string): Promise<DecodedGif> {
+	// Convert data URL to blob for ImageDecoder
+	const resp = await fetch(dataUrl);
+	const blob = await resp.blob();
+
+	// Check if ImageDecoder API is available (Chromium 94+)
+	if (typeof ImageDecoder === "undefined") {
+		// Fallback: single static frame
+		return decodeGifFallback(dataUrl);
+	}
+
+	try {
+		const decoder = new ImageDecoder({
+			data: blob.stream(),
+			type: "image/gif",
+		});
+
+		await decoder.completed;
+
+		const track = decoder.tracks.selectedTrack;
+		if (!track || track.frameCount === 0) {
+			decoder.close();
+			return decodeGifFallback(dataUrl);
+		}
+
+		const frameCount = track.frameCount;
+		const frames: ImageBitmap[] = [];
+		const frameTimes: number[] = [];
+		let cumulative = 0;
+
+		for (let i = 0; i < frameCount; i++) {
+			const result = await decoder.decode({ frameIndex: i });
+			const vf = result.image;
+
+			// VideoFrame.duration is in microseconds
+			const delayMs = (vf.duration ?? 100_000) / 1000;
+			cumulative += delayMs;
+
+			// Convert VideoFrame to ImageBitmap for canvas drawing
+			const bitmap = await createImageBitmap(vf);
+			vf.close();
+
+			frames.push(bitmap);
+			frameTimes.push(cumulative);
+		}
+
+		decoder.close();
+
+		return {
+			frames,
+			frameTimes,
+			totalDurationMs: cumulative,
+		};
+	} catch {
+		return decodeGifFallback(dataUrl);
+	}
+}
+
+/** Fallback: load as a single static image. */
+async function decodeGifFallback(dataUrl: string): Promise<DecodedGif> {
+	const bitmap = await new Promise<ImageBitmap>((resolve, reject) => {
+		const img = new Image();
+		img.onload = () => createImageBitmap(img).then(resolve).catch(reject);
+		img.onerror = reject;
+		img.src = dataUrl;
+	});
+	return {
+		frames: [bitmap],
+		frameTimes: [100],
+		totalDurationMs: 100,
+	};
+}
+
+/**
+ * Get the correct GIF frame for a given elapsed time (ms) since the
+ * annotation started. Loops automatically.
+ */
+export function getGifFrameAtTime(gif: DecodedGif, elapsedMs: number): ImageBitmap {
+	if (gif.frames.length === 1) return gif.frames[0];
+
+	const looped = elapsedMs % gif.totalDurationMs;
+	for (let i = 0; i < gif.frameTimes.length; i++) {
+		if (looped < gif.frameTimes[i]) return gif.frames[i];
+	}
+	return gif.frames[gif.frames.length - 1];
+}
+
+/**
+ * Clear the decoded-GIF cache (e.g. when a project is closed).
+ */
+export function clearGifCache(): void {
+	gifCache.clear();
+}


### PR DESCRIPTION
## Summary
- Re-enable webcam background removal panel (Remove/Blur/Color modes) that was shelved
- Add animated GIF frame-accurate rendering during export using Chromium ImageDecoder API
- Wire up Giphy scratch pad "Restore" button to actually place clips as image annotation overlays on the timeline

## Test plan
- [ ] Open webcam settings → verify Background Removal panel appears with None/Remove/Blur/Color options
- [ ] Add a GIF image as an annotation overlay → export video → verify GIF animates in the exported file
- [ ] Search Giphy clips → add to scratch pad → click Restore → verify overlay appears on timeline at current time
- [ ] Drag/resize the restored Giphy overlay → verify it persists through save/load

https://claude.ai/code/session_01QYqshu3KHeudTXDCEnMRje